### PR TITLE
Fixing a 404 link

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@ Original: www.nazhamid.com
 License: MIT/GPL
 
 https://github.com/weightshift/The-Personal-Page
-http://weightshift.com/memo/the-personal-page
+http://thepersonalpage.me/
 
 The site makes use of the jQuery Backstretch plugin 
 from Scott Robbin. Gracias.


### PR DESCRIPTION
Fixed link to the project page. Memo section link was a 404. Probably due to site structure change.
